### PR TITLE
fix: only use multiline input_dialog for copyright header

### DIFF
--- a/ozi_core/new/interactive/dialog.py
+++ b/ozi_core/new/interactive/dialog.py
@@ -193,6 +193,7 @@ def input_dialog(
     validator: Validator | None = None,
     password: FilterOrBool = False,
     style: BaseStyle | None = None,
+    multiline: bool = False,
     default: str = '',
 ) -> Application[str]:
     """
@@ -217,7 +218,7 @@ def input_dialog(
     longest_line = len(max(lines, key=len)) if len(lines) > 0 else 40
     textfield = TextArea(
         text=default,
-        multiline=True,
+        multiline=multiline,
         password=password,
         completer=completer,
         validator=validator,

--- a/ozi_core/new/interactive/dialog.pyi
+++ b/ozi_core/new/interactive/dialog.pyi
@@ -38,7 +38,7 @@ def admonition_dialog(title: str = ..., text: str = ..., heading_label: str = ..
     """
     ...
 
-def input_dialog(title: AnyFormattedText = ..., text: AnyFormattedText = ..., ok_text: str | None = ..., cancel_text: str | None = ..., completer: Completer | None = ..., validator: Validator | None = ..., password: FilterOrBool = ..., style: BaseStyle | None = ..., default: str = ...) -> Application[str]:
+def input_dialog(title: AnyFormattedText = ..., text: AnyFormattedText = ..., ok_text: str | None = ..., cancel_text: str | None = ..., completer: Completer | None = ..., validator: Validator | None = ..., password: FilterOrBool = ..., style: BaseStyle | None = ..., multiline: bool = ..., default: str = ...) -> Application[str]:
     """
     Display a text input box.
     Return the given text, or None when cancelled.

--- a/ozi_core/new/interactive/menu.py
+++ b/ozi_core/new/interactive/menu.py
@@ -218,6 +218,7 @@ def options_menu(  # pragma: no cover
                     cancel_text=TRANSLATION('btn-back'),
                     ok_text=TRANSLATION('btn-ok'),
                     default=_default[0],
+                    multiline=True,
                 ).run()
                 if result in _default:
                     project.copyright_head = result


### PR DESCRIPTION
Signed-off-by: rjdbcm <rjdbcm@outlook.com>